### PR TITLE
Fix issue #3 and add additional command line options

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,17 +23,25 @@ We run our own private registry on a server with limited storage and it was only
 ```
 -day int
       max age in days
+-debug
+      run in debug mode      
 -dry
       does not actually deletes
 -month int
       max age in months
 -registry string
       URL of registry (default "http://localhost:5000")
+-repo string
+      matching repositories (allows regexp) (default ".*")      
 -repos int
       number of repositories to garbage collect (default 5)
+-tag string
+      matching tags (allows regexp) (default ".*")      
 -v    shows version and quits
 -year int
       max age in days
+      
+      
 ```
 
 ## Examples
@@ -54,4 +62,16 @@ $GOPATH/bin/deckschrubber -year 1 -registry http://myrepo:5000
 
 ```
 $GOPATH/bin/deckschrubber -repos 30 -dry
+```
+
+* **Remove all images of each repository except the 3 latest ones**
+
+```
+$GOPATH/bin/deckschrubber -latest 3 
+```
+
+* **Remove all images with tags that ends with '-SNAPSHOT'**
+
+```
+$GOPATH/bin/deckschrubber -tag ^.*-SNAPSHOT$ 
 ```

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ We run our own private registry on a server with limited storage and it was only
       run in debug mode      
 -dry
       does not actually deletes
+-latest int
+      number of the latest matching images of an repository that won't be deleted (default 1)      
 -month int
       max age in months
 -registry string


### PR DESCRIPTION
@yan-foto This PR fixes issue #3 as well as introduces some useful command line options such like:
```
-debug
      run in debug mode
-latest int
      number of the latest matching images of an repository that won't be deleted (default 1)      
-repo string
      matching repositories (allows regexp) (default ".*") 
-tag string
      matching tags (allows regexp) (default ".*")
```