### PR TITLE
Corrected behavior with images that have more than one tag

### DIFF
--- a/types.go
+++ b/types.go
@@ -1,6 +1,11 @@
 package main
 
-import "time"
+import (
+        "time"
+
+        "github.com/docker/distribution"
+)
+
 
 // BlobInfo represents information about a specific Blob
 type BlobInfo struct {
@@ -12,7 +17,7 @@ type Image struct {
 	Repository string       // Name of repository to which image belongs
 	Tag        string       // Image's tag
 	Time       time.Time    // Creation time of the image
-	Delete     func() error // Function to delete image from registry
+	Descriptor distribution.Descriptor	// Underlying image descriptor
 }
 
 // ImageByDate represents an array of images


### PR DESCRIPTION
This pull request adds no new features, only a bug fix and what I think is a more sensible meaning of combination of flags:

- Corrected behavior with images that have more than one tag (bug #9).
- Changed the meaning of time-limit (e.g -day) in combination with -latest flag: it only takes into account whichever means more preserved matching tags (instead of combining their effect as original code)

I can also paste test scripts for the first item (I'd have to clean them up a bit first).