### PR TITLE
Add a new flag for matching "everything but this" tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ We run our own private registry on a server with limited storage and it was only
       number of repositories to garbage collect (default 5)
 -tag string
       matching tags (allows regexp) (default ".*")      
+-ntag string
+      match everything but this tag (allows regexp) (default empty)
 -v    shows version and quits
 -year int
       max age in days

--- a/main.go
+++ b/main.go
@@ -251,8 +251,12 @@ func main() {
 			}
 		}
 
-		// This approach is actually a workaround for the problem that Docker Distribution doesn't implement TagService.Untag operation at the time of this writing
-		// Actually we have to delete the underlying image (specified via its Digest value), taking care not to delete images that are referenced by tags which we want to preserve
+		// This approach is actually a workaround for the problem that Docker
+		// Distribution doesn't implement TagService.Untag operation at the time of
+		// this writing.
+		// Actually we have to delete the underlying image (specified via its Digest
+		// value), taking care not to delete images that are referenced by tags which
+		// we want to preserve
 		nonDeletableDigests := make(map[string]string)
 		for _, tag := range nonDeletableTags {
 			if nonDeletableDigests[tag.Descriptor.Digest.String()] == "" {

--- a/main.go
+++ b/main.go
@@ -214,14 +214,14 @@ func main() {
 			continue
 		}
 
-		deletableTags := make(map[int] Image);
-		nonDeletableTags := make(map[int] Image);
+		deletableTags := make(map[int]Image)
+		nonDeletableTags := make(map[int]Image)
 
 		ignoredTags := 0
 
-		for tagIndex := len(tags)-1; tagIndex >= 0; tagIndex-- {
+		for tagIndex := len(tags) - 1; tagIndex >= 0; tagIndex-- {
 			tag := tags[tagIndex]
-			markForDeletion := false;
+			markForDeletion := false
 			tagLogger := logger.WithField("tag", tag.Tag)
 
 			matched, _ := regexp.MatchString(*tagRegexp, tag.Tag)
@@ -253,7 +253,7 @@ func main() {
 
 		// This approach is actually a workaround for the problem that Docker Distribution doesn't implement TagService.Untag operation at the time of this writing
 		// Actually we have to delete the underlying image (specified via its Digest value), taking care not to delete images that are referenced by tags which we want to preserve
-		nonDeletableDigests := make(map[string] string)
+		nonDeletableDigests := make(map[string]string)
 		for _, tag := range nonDeletableTags {
 			if nonDeletableDigests[tag.Descriptor.Digest.String()] == "" {
 				nonDeletableDigests[tag.Descriptor.Digest.String()] = tag.Tag
@@ -262,7 +262,7 @@ func main() {
 			}
 		}
 
-		digestsDeleted := make(map[string] bool)
+		digestsDeleted := make(map[string]bool)
 		for _, tag := range deletableTags {
 			if !digestsDeleted[tag.Descriptor.Digest.String()] {
 				if nonDeletableDigests[tag.Descriptor.Digest.String()] == "" {

--- a/main.go
+++ b/main.go
@@ -231,14 +231,14 @@ func main() {
 				if tag.Time.Before(deadline) {
 					if ignoredTags < *latest {
 						tagLogger.WithField("time", tag.Time).Infof("Ignore %d latest matching tags (-latest=%d)", *latest, *latest)
-						ignoredTags += 1
+						ignoredTags++
 					} else {
 						tagLogger.WithField("tag", tag.Tag).WithField("time", tag.Time).Infof("Marking tag as outdated")
 						markForDeletion = true
 					}
 				} else {
 					tagLogger.Info("Tag not outdated")
-					ignoredTags += 1
+					ignoredTags++
 				}
 			} else {
 				tagLogger.Info("Ignore non matching tag (-tag=", *tagRegexp, ")")

--- a/types.go
+++ b/types.go
@@ -1,11 +1,10 @@
 package main
 
 import (
-        "time"
+	"time"
 
-        "github.com/docker/distribution"
+	"github.com/docker/distribution"
 )
-
 
 // BlobInfo represents information about a specific Blob
 type BlobInfo struct {
@@ -14,10 +13,10 @@ type BlobInfo struct {
 
 // Image represents a docker image with a specific tag
 type Image struct {
-	Repository string       // Name of repository to which image belongs
-	Tag        string       // Image's tag
-	Time       time.Time    // Creation time of the image
-	Descriptor distribution.Descriptor	// Underlying image descriptor
+	Repository string                  // Name of repository to which image belongs
+	Tag        string                  // Image's tag
+	Time       time.Time               // Creation time of the image
+	Descriptor distribution.Descriptor // Underlying image descriptor
 }
 
 // ImageByDate represents an array of images


### PR DESCRIPTION
```sh
deckschrubber -repo "^my-repo$" -ntag "^(foo|bar)_"
```

The new flag `-ntag` is compatible and can be used along with `-tag` in an AND fashion.

I also took the opportunity to compile the regular expressions beforehand, and not within the loop.

The code was formatted with `goreturns` in order to get rid of some irregular formatting since the last PR. I am not sure whether this project has a preferred formatting filter.
