### PR TITLE
Add registry preparation section to help new users

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,17 @@ We run our own private registry on a server with limited storage and it was only
       
 ```
 
+## Registry preparation
+Deckschrubber uses the Docker Registry API. 
+Its delete endpoint is disabled by default, you have to enable it with the following entry in the registry configuration file: 
+
+```
+delete:
+  enabled: true
+```
+
+See [the documentation](https://github.com/docker/distribution/blob/master/docs/configuration.md#delete) for details. 
+
 ## Examples
 
 * **Remove all images older than 2 months and 2 days**


### PR DESCRIPTION
Maybe I'm just a bit daft, but I took my time figuring out why deckschrubber wasn't working, until I got that delete is disabled by default in the registry. 
Please help others like my by merging this updated README (or by writing something better yourself). ;-)