### PR TITLE
Don't exit when errors are encountered on a repo

### DIFF
--- a/main.go
+++ b/main.go
@@ -150,12 +150,14 @@ func main() {
 		blobsService := repo.Blobs(ctx)
 		manifestService, err := repo.Manifests(ctx)
 		if err != nil {
-			logger.Fatalf("Couldn't fetch manifest service! (err: %v)", err)
+			logger.Warnln("Couldn't fetch manifest service - not processing this repo (err: %v)", err)
+			continue
 		}
 
 		tagsData, err := tagsService.All(ctx)
 		if err != nil {
-			logger.Fatalf("Couldn't fetch tags! (err: %v)", err)
+			logger.Warnln("Couldn't fetch tags - not processing this repo (err: %v)", err)
+			continue
 		}
 
 		var tags []Image


### PR DESCRIPTION
When a particular repo has errors in its data, this caused the deckschrubber to stop processing and not scrub the next repositories on the list. With this change, it will continue on to the next repository and only print a warning (of course the registry admin should fix the problem with that repo, but this should not block the cleanup from working).