### PR TITLE
Compact logged list of fetched repos

### DIFF
--- a/main.go
+++ b/main.go
@@ -143,7 +143,7 @@ func main() {
 	if err != nil && err != io.EOF {
 		log.Fatalf("Error while fetching repositories! (err: %v)", err)
 	}
-	log.WithFields(log.Fields{"count": numFilled, "entries": entries}).Info("Successfully fetched repositories.")
+	log.WithFields(log.Fields{"count": numFilled, "entries": entries[:numFilled]}).Info("Successfully fetched repositories.")
 
 	// Deadline defines the youngest creation date for an image
 	// to be considered for deletion


### PR DESCRIPTION
Do not log extra empty entries for fetched repos (especially with json log formatter).

## Before

```bash
deckschrubber ... -repos 50

INFO[0003] Successfully fetched repositories.            count=7 entries="repo1 repo2 repo3                                                                   ]"
```

## After

```bash
deckschrubber ... -repos 50

INFO[0003] Successfully fetched repositories.            count=3 entries="repo1 repo2 repo3]"
```