### PR TITLE
add negative match for repositories (regexp)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ We run our own private registry on a server with limited storage and it was only
       URL of registry (default "http://localhost:5000")
 -repo string
       matching repositories (allows regexp) (default ".*")      
+-nrepo string
+      matching everything but this repo (allows regexp) (default empty)          
 -repos int
       number of repositories to garbage collect (default 5)
 -tag string


### PR DESCRIPTION
We faced the problem that we wanted to explicitly exclude certain repositories. As this is quite cumbersome to do with regexpressions, we added a negative match for repositories, the same way it is already possible to negatively match tags. It would be nice if this can be merged into the projects so that we don't have to maintain our own version. Thanks!