### PR TITLE
Get the list of repositories with multiple calls with paging

### DIFF
--- a/main.go
+++ b/main.go
@@ -60,8 +60,8 @@ const (
 
 func init() {
 	/** CLI flags */
-	// Max number of repositories to fetch from registry (default = 5)
-	repoCount = flag.Int("repos", 5, "number of repositories to garbage collect")
+	// Max number of repositories to fetch from registry (obsolete, kept for backward compatibility with existing scripts)
+	repoCount = flag.Int("repos", 0, "number of repositories to garbage collect (ignored, kept for backward compatibility)")
 	// Base URL of registry (default = http://localhost:5000)
 	registryURL = flag.String("registry", "http://localhost:5000", "URL of registry")
 	// Maximum age of iamges to consider for deletion in days (default = 0)
@@ -113,6 +113,10 @@ func main() {
 
 	if *debug {
 		log.SetLevel(log.DebugLevel)
+	}
+
+	if *repoCount != 0 {
+		log.Warn("Option -repos is obsolete, ignored")
 	}
 
 	// Add basic auth if user/pass is provided


### PR DESCRIPTION
This feature improves support for Docker repositories which don't support increasing the configurable limit of repositories obtained by single API call to /v2/_catalog (such as the GitLab built in registry).

It should also reduce the cases of timeouts in cases where the registry is slow and contains large number of repos (#17).

Existing option `-repos` is kept, but is ignored and produces a warning if used: I presumed this option was implemented to allow adjusting to different max repos limits and not to actually be used for specifying what to clean. 

This behavior is not backwards compatible and may break some setups - I can change this so that the existing behavior is preserved (so that only first specified number of repos are cleaned).
