### PR TITLE
Fix pagination panic: pass allocated buffer to Repositories() instead of empty slice

### DIFF
--- a/main.go
+++ b/main.go
@@ -157,12 +157,12 @@ func main() {
 		// The size of 'es' determines the number of repositories
 		// that are being queried by us
 		es := make([]string, windowSize)
-		n, err := r.Repositories(ctx, entries, last)
+		n, err := r.Repositories(ctx, es, last)
 		if err != nil && err != io.EOF {
 			log.Fatalf("Error while fetching repositories! (err: %v)", err)
 		}
 
-		log.WithFields(log.Fields{"count": n, "entries": entries[:n]}).Info("Successfully fetched repositories.")
+		log.WithFields(log.Fields{"count": n, "entries": es[:n]}).Info("Successfully fetched repositories.")
 		entries = append(entries, es[:n]...)
 
 		// Stop the query if:


### PR DESCRIPTION
## Summary

- Fixes a panic caused by passing the empty `entries` slice to `r.Repositories()` instead of the pre-allocated `es` buffer
- The `es` slice (allocated with `windowSize` capacity) is the intended buffer for receiving repository names, but was mistakenly not used in the `Repositories()` call and subsequent log statement
- This caused an index out-of-range panic when the registry returned repositories, since `entries` starts empty and `es[:n]` was never populated

## Changes

**`main.go`**: Replace `entries` with `es` in the `r.Repositories(ctx, ...)` call and the corresponding log line, matching the original intent of the allocated buffer.