### PR TITLE
Safe deletion of images with shared digests via two-phase process and manifest-based retagging

### DIFF
--- a/main.go
+++ b/main.go
@@ -362,28 +362,32 @@ func main() {
 			}
 		}
 
+		deletionOrder := make([]int, 0, len(deletableTags))
+		for tagIndex := range deletableTags {
+			deletionOrder = append(deletionOrder, tagIndex)
+		}
+		sort.Ints(deletionOrder)
+
+		replacementDigestOrder := make([]string, 0, len(replacementDigests))
+		for digest := range replacementDigests {
+			replacementDigestOrder = append(replacementDigestOrder, digest)
+		}
+		sort.Strings(replacementDigestOrder)
+
 		digestsDeleted := make(map[string]bool)
-		for _, tag := range deletableTags {
+
+		// Phase 1: shared digests first. Retag outdated tags to disposable
+		// digests and delete those disposable digests.
+		for _, tagIndex := range deletionOrder {
+			tag := deletableTags[tagIndex]
 			digest := tag.Descriptor.Digest.String()
 			if !digestsDeleted[digest] {
 				nonDeletableTagsForDigest, hasNonDeletableTags := nonDeletableDigests[digest]
-				if !hasNonDeletableTags {
-					logger.WithField("tag", tag.Tag).Info("All tags for this image digest marked for deletion")
-					if !*dry {
-						logger.WithField("tag", tag.Tag).WithField("time", tag.Time).WithField("digest", tag.Descriptor.Digest).Infof("Deleting image (-dry=%v)", *dry)
-						err := manifestService.Delete(ctx, tag.Descriptor.Digest)
-						if err == nil {
-							digestsDeleted[digest] = true
-						} else {
-							logger.WithField("tag", tag.Tag).WithField("err", err).Error("Could not delete image!")
-						}
-					} else {
-						logger.WithField("tag", tag.Tag).WithField("time", tag.Time).Infof("Not actually deleting image (-dry=%v)", *dry)
-					}
-				} else {
+				if hasNonDeletableTags {
 					replacementFound := false
 					var replacementTag Image
-					for replacementDigest, candidateTag := range replacementDigests {
+					for _, replacementDigest := range replacementDigestOrder {
+						candidateTag := replacementDigests[replacementDigest]
 						if replacementDigest != digest && !digestsDeleted[replacementDigest] {
 							replacementTag = candidateTag
 							replacementFound = true
@@ -414,9 +418,39 @@ func main() {
 					}
 
 					digestsDeleted[replacementTag.Descriptor.Digest.String()] = true
+				} else {
+					logger.WithField("tag", tag.Tag).Debug("Digest is not shared - defer direct deletion to phase 2")
 				}
 			} else {
 				logger.WithField("tag", tag.Tag).Debug("Image under tag already deleted")
+			}
+		}
+
+		// Phase 2: non-shared digests. Delete digest directly.
+		for _, tagIndex := range deletionOrder {
+			tag := deletableTags[tagIndex]
+			digest := tag.Descriptor.Digest.String()
+			if digestsDeleted[digest] {
+				logger.WithField("tag", tag.Tag).Debug("Image under tag already deleted")
+				continue
+			}
+
+			if _, hasNonDeletableTags := nonDeletableDigests[digest]; hasNonDeletableTags {
+				logger.WithField("tag", tag.Tag).Debug("Digest is shared - already handled in phase 1")
+				continue
+			}
+
+			logger.WithField("tag", tag.Tag).Info("All tags for this image digest marked for deletion")
+			if !*dry {
+				logger.WithField("tag", tag.Tag).WithField("time", tag.Time).WithField("digest", tag.Descriptor.Digest).Infof("Deleting image (-dry=%v)", *dry)
+				err := manifestService.Delete(ctx, tag.Descriptor.Digest)
+				if err == nil {
+					digestsDeleted[digest] = true
+				} else {
+					logger.WithField("tag", tag.Tag).WithField("err", err).Error("Could not delete image!")
+				}
+			} else {
+				logger.WithField("tag", tag.Tag).WithField("time", tag.Time).Infof("Not actually deleting image (-dry=%v)", *dry)
 			}
 		}
 

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/distribution/reference"
+	"github.com/docker/distribution"
 	"github.com/docker/distribution/context"
 	schema2 "github.com/docker/distribution/manifest/schema2"
 	"github.com/docker/distribution/registry/client"
@@ -407,7 +408,16 @@ func main() {
 				continue
 			}
 
-			if err := tagsService.Tag(ctx, tag.Tag, replacementTag.Descriptor); err != nil {
+			// TagService.Tag() is not implemented in the client library,
+			// so we retag by fetching the replacement manifest and pushing
+			// it under the target tag name via ManifestService.Put().
+			replacementManifest, err := manifestService.Get(ctx, replacementTag.Descriptor.Digest)
+			if err != nil {
+				logger.WithField("tag", tag.Tag).WithField("replacementDigest", replacementTag.Descriptor.Digest.String()).WithField("err", err).Error("Could not fetch replacement manifest for retagging!")
+				continue
+			}
+
+			if _, err := manifestService.Put(ctx, replacementManifest, distribution.WithTag(tag.Tag)); err != nil {
 				logger.WithField("tag", tag.Tag).WithField("replacementDigest", replacementTag.Descriptor.Digest.String()).WithField("err", err).Error("Could not retag image to disposable digest!")
 				continue
 			}

--- a/main.go
+++ b/main.go
@@ -367,11 +367,6 @@ func main() {
 			deletionOrder = append(deletionOrder, tagIndex)
 		}
 
-		replacementDigestOrder := make([]string, 0, len(replacementDigests))
-		for digest := range replacementDigests {
-			replacementDigestOrder = append(replacementDigestOrder, digest)
-		}
-
 		digestsDeleted := make(map[string]bool)
 
 		// Phase 1: shared digests first. Retag outdated tags to disposable
@@ -391,23 +386,27 @@ func main() {
 				continue
 			}
 
-			replacementFound := false
+			var replacementDigest string
 			var replacementTag Image
-			for _, replacementDigest := range replacementDigestOrder {
-				candidateTag := replacementDigests[replacementDigest]
-				if replacementDigest != digest && !digestsDeleted[replacementDigest] {
+			for candidateDigest, candidateTag := range replacementDigests {
+				if candidateDigest != digest {
+					replacementDigest = candidateDigest
 					replacementTag = candidateTag
-					replacementFound = true
 					break
 				}
 			}
 
-			if !replacementFound {
+			if replacementDigest == "" {
 				logger.WithField("tag", tag.Tag).WithField("alsoUsedByTags", nonDeletableTagsForDigest).Info("The underlying image is also used by non-deletable tags and no disposable replacement digest is available - skipping deletion")
 				continue
 			}
 
-			logger.WithField("tag", tag.Tag).WithField("sharedDigest", digest).WithField("alsoUsedByTags", nonDeletableTagsForDigest).WithField("replacementDigest", replacementTag.Descriptor.Digest.String()).Info("Digest is shared with non-deletable tags - retagging to disposable digest for safe untag")
+			logger.
+				WithField("tag", tag.Tag).
+				WithField("sharedDigest", digest).
+				WithField("alsoUsedByTags", nonDeletableTagsForDigest).
+				WithField("replacementDigest", replacementTag.Descriptor.Digest.String()).
+				Info("Digest is shared with non-deletable tags - retagging to disposable digest for safe untag")
 
 			if *dry {
 				logger.WithField("tag", tag.Tag).WithField("replacementDigest", replacementTag.Descriptor.Digest.String()).Infof("Not actually retagging/deleting digest (-dry=%v)", *dry)
@@ -424,7 +423,8 @@ func main() {
 				continue
 			}
 
-			digestsDeleted[replacementTag.Descriptor.Digest.String()] = true
+			delete(replacementDigests, replacementDigest)
+			digestsDeleted[replacementDigest] = true
 		}
 
 		// Phase 2: non-shared digests. Delete digest directly.

--- a/main.go
+++ b/main.go
@@ -381,55 +381,59 @@ func main() {
 		for _, tagIndex := range deletionOrder {
 			tag := deletableTags[tagIndex]
 			digest := tag.Descriptor.Digest.String()
-			if !digestsDeleted[digest] {
-				nonDeletableTagsForDigest, hasNonDeletableTags := nonDeletableDigests[digest]
-				if hasNonDeletableTags {
-					replacementFound := false
-					var replacementTag Image
-					for _, replacementDigest := range replacementDigestOrder {
-						candidateTag := replacementDigests[replacementDigest]
-						if replacementDigest != digest && !digestsDeleted[replacementDigest] {
-							replacementTag = candidateTag
-							replacementFound = true
-							break
-						}
-					}
 
-					if !replacementFound {
-						logger.WithField("tag", tag.Tag).WithField("alsoUsedByTags", nonDeletableTagsForDigest).Info("The underlying image is also used by non-deletable tags and no disposable replacement digest is available - skipping deletion")
-						continue
-					}
-
-					logger.WithField("tag", tag.Tag).WithField("sharedDigest", digest).WithField("alsoUsedByTags", nonDeletableTagsForDigest).WithField("replacementDigest", replacementTag.Descriptor.Digest.String()).Info("Digest is shared with non-deletable tags - retagging to disposable digest for safe untag")
-
-					if *dry {
-						logger.WithField("tag", tag.Tag).WithField("replacementDigest", replacementTag.Descriptor.Digest.String()).Infof("Not actually retagging/deleting digest (-dry=%v)", *dry)
-						continue
-					}
-
-					if err := tagsService.Tag(ctx, tag.Tag, replacementTag.Descriptor); err != nil {
-						logger.WithField("tag", tag.Tag).WithField("replacementDigest", replacementTag.Descriptor.Digest.String()).WithField("err", err).Error("Could not retag image to disposable digest!")
-						continue
-					}
-
-					if err := manifestService.Delete(ctx, replacementTag.Descriptor.Digest); err != nil {
-						logger.WithField("tag", tag.Tag).WithField("replacementDigest", replacementTag.Descriptor.Digest.String()).WithField("err", err).Error("Could not delete disposable digest after retagging!")
-						continue
-					}
-
-					digestsDeleted[replacementTag.Descriptor.Digest.String()] = true
-				} else {
-					logger.WithField("tag", tag.Tag).Debug("Digest is not shared - defer direct deletion to phase 2")
-				}
-			} else {
+			if digestsDeleted[digest] {
 				logger.WithField("tag", tag.Tag).Debug("Image under tag already deleted")
+				continue
 			}
+
+			nonDeletableTagsForDigest, hasNonDeletableTags := nonDeletableDigests[digest]
+			if !hasNonDeletableTags {
+				logger.WithField("tag", tag.Tag).Debug("Digest is not shared - defer direct deletion to phase 2")
+				continue
+			}
+
+			replacementFound := false
+			var replacementTag Image
+			for _, replacementDigest := range replacementDigestOrder {
+				candidateTag := replacementDigests[replacementDigest]
+				if replacementDigest != digest && !digestsDeleted[replacementDigest] {
+					replacementTag = candidateTag
+					replacementFound = true
+					break
+				}
+			}
+
+			if !replacementFound {
+				logger.WithField("tag", tag.Tag).WithField("alsoUsedByTags", nonDeletableTagsForDigest).Info("The underlying image is also used by non-deletable tags and no disposable replacement digest is available - skipping deletion")
+				continue
+			}
+
+			logger.WithField("tag", tag.Tag).WithField("sharedDigest", digest).WithField("alsoUsedByTags", nonDeletableTagsForDigest).WithField("replacementDigest", replacementTag.Descriptor.Digest.String()).Info("Digest is shared with non-deletable tags - retagging to disposable digest for safe untag")
+
+			if *dry {
+				logger.WithField("tag", tag.Tag).WithField("replacementDigest", replacementTag.Descriptor.Digest.String()).Infof("Not actually retagging/deleting digest (-dry=%v)", *dry)
+				continue
+			}
+
+			if err := tagsService.Tag(ctx, tag.Tag, replacementTag.Descriptor); err != nil {
+				logger.WithField("tag", tag.Tag).WithField("replacementDigest", replacementTag.Descriptor.Digest.String()).WithField("err", err).Error("Could not retag image to disposable digest!")
+				continue
+			}
+
+			if err := manifestService.Delete(ctx, replacementTag.Descriptor.Digest); err != nil {
+				logger.WithField("tag", tag.Tag).WithField("replacementDigest", replacementTag.Descriptor.Digest.String()).WithField("err", err).Error("Could not delete disposable digest after retagging!")
+				continue
+			}
+
+			digestsDeleted[replacementTag.Descriptor.Digest.String()] = true
 		}
 
 		// Phase 2: non-shared digests. Delete digest directly.
 		for _, tagIndex := range deletionOrder {
 			tag := deletableTags[tagIndex]
 			digest := tag.Descriptor.Digest.String()
+
 			if digestsDeleted[digest] {
 				logger.WithField("tag", tag.Tag).Debug("Image under tag already deleted")
 				continue
@@ -441,17 +445,20 @@ func main() {
 			}
 
 			logger.WithField("tag", tag.Tag).Info("All tags for this image digest marked for deletion")
-			if !*dry {
-				logger.WithField("tag", tag.Tag).WithField("time", tag.Time).WithField("digest", tag.Descriptor.Digest).Infof("Deleting image (-dry=%v)", *dry)
-				err := manifestService.Delete(ctx, tag.Descriptor.Digest)
-				if err == nil {
-					digestsDeleted[digest] = true
-				} else {
-					logger.WithField("tag", tag.Tag).WithField("err", err).Error("Could not delete image!")
-				}
-			} else {
+
+			if *dry {
 				logger.WithField("tag", tag.Tag).WithField("time", tag.Time).Infof("Not actually deleting image (-dry=%v)", *dry)
+				continue
 			}
+
+			logger.WithField("tag", tag.Tag).WithField("time", tag.Time).WithField("digest", tag.Descriptor.Digest).Infof("Deleting image (-dry=%v)", *dry)
+			err := manifestService.Delete(ctx, tag.Descriptor.Digest)
+			if err != nil {
+				logger.WithField("tag", tag.Tag).WithField("err", err).Error("Could not delete image!")
+				continue
+			}
+
+			digestsDeleted[digest] = true
 		}
 
 	}

--- a/main.go
+++ b/main.go
@@ -346,17 +346,18 @@ func main() {
 		// delete that disposable digest.
 		nonDeletableDigests := make(map[string]string)
 		for _, tag := range nonDeletableTags {
-			if nonDeletableDigests[tag.Descriptor.Digest.String()] == "" {
-				nonDeletableDigests[tag.Descriptor.Digest.String()] = tag.Tag
+			digest := tag.Descriptor.Digest.String()
+			if existingTags, exists := nonDeletableDigests[digest]; !exists {
+				nonDeletableDigests[digest] = tag.Tag
 			} else {
-				nonDeletableDigests[tag.Descriptor.Digest.String()] = nonDeletableDigests[tag.Descriptor.Digest.String()] + ", " + tag.Tag
+				nonDeletableDigests[digest] = existingTags + ", " + tag.Tag
 			}
 		}
 
 		replacementDigests := make(map[string]Image)
 		for _, tag := range deletableTags {
 			digest := tag.Descriptor.Digest.String()
-			if nonDeletableDigests[digest] == "" {
+			if _, exists := nonDeletableDigests[digest]; !exists {
 				replacementDigests[digest] = tag
 			}
 		}
@@ -365,8 +366,8 @@ func main() {
 		for _, tag := range deletableTags {
 			digest := tag.Descriptor.Digest.String()
 			if !digestsDeleted[digest] {
-				nonDeletableTagsForDigest := nonDeletableDigests[digest]
-				if nonDeletableTagsForDigest == "" {
+				nonDeletableTagsForDigest, hasNonDeletableTags := nonDeletableDigests[digest]
+				if !hasNonDeletableTags {
 					logger.WithField("tag", tag.Tag).Info("All tags for this image digest marked for deletion")
 					if !*dry {
 						logger.WithField("tag", tag.Tag).WithField("time", tag.Time).WithField("digest", tag.Descriptor.Digest).Infof("Deleting image (-dry=%v)", *dry)

--- a/main.go
+++ b/main.go
@@ -341,9 +341,9 @@ func main() {
 		// This approach is actually a workaround for the problem that Docker
 		// Distribution doesn't implement TagService.Untag operation at the time of
 		// this writing.
-		// Actually we have to delete the underlying image (specified via its Digest
-		// value), taking care not to delete images that are referenced by tags which
-		// we want to preserve
+		// We delete image digests for outdated tags. If a digest is shared with tags
+		// we must preserve, we retag the outdated tag to a disposable digest and then
+		// delete that disposable digest.
 		nonDeletableDigests := make(map[string]string)
 		for _, tag := range nonDeletableTags {
 			if nonDeletableDigests[tag.Descriptor.Digest.String()] == "" {
@@ -353,16 +353,26 @@ func main() {
 			}
 		}
 
+		replacementDigests := make(map[string]Image)
+		for _, tag := range deletableTags {
+			digest := tag.Descriptor.Digest.String()
+			if nonDeletableDigests[digest] == "" {
+				replacementDigests[digest] = tag
+			}
+		}
+
 		digestsDeleted := make(map[string]bool)
 		for _, tag := range deletableTags {
-			if !digestsDeleted[tag.Descriptor.Digest.String()] {
-				if nonDeletableDigests[tag.Descriptor.Digest.String()] == "" {
+			digest := tag.Descriptor.Digest.String()
+			if !digestsDeleted[digest] {
+				nonDeletableTagsForDigest := nonDeletableDigests[digest]
+				if nonDeletableTagsForDigest == "" {
 					logger.WithField("tag", tag.Tag).Info("All tags for this image digest marked for deletion")
 					if !*dry {
 						logger.WithField("tag", tag.Tag).WithField("time", tag.Time).WithField("digest", tag.Descriptor.Digest).Infof("Deleting image (-dry=%v)", *dry)
-						err := manifestService.Delete(context.Background(), tag.Descriptor.Digest)
+						err := manifestService.Delete(ctx, tag.Descriptor.Digest)
 						if err == nil {
-							digestsDeleted[tag.Descriptor.Digest.String()] = true
+							digestsDeleted[digest] = true
 						} else {
 							logger.WithField("tag", tag.Tag).WithField("err", err).Error("Could not delete image!")
 						}
@@ -370,7 +380,39 @@ func main() {
 						logger.WithField("tag", tag.Tag).WithField("time", tag.Time).Infof("Not actually deleting image (-dry=%v)", *dry)
 					}
 				} else {
-					logger.WithField("tag", tag.Tag).WithField("alsoUsedByTags", nonDeletableDigests[tag.Descriptor.Digest.String()]).Infof("The underlying image is also used by non-deletable tags - skipping deletion")
+					replacementFound := false
+					var replacementTag Image
+					for replacementDigest, candidateTag := range replacementDigests {
+						if replacementDigest != digest && !digestsDeleted[replacementDigest] {
+							replacementTag = candidateTag
+							replacementFound = true
+							break
+						}
+					}
+
+					if !replacementFound {
+						logger.WithField("tag", tag.Tag).WithField("alsoUsedByTags", nonDeletableTagsForDigest).Info("The underlying image is also used by non-deletable tags and no disposable replacement digest is available - skipping deletion")
+						continue
+					}
+
+					logger.WithField("tag", tag.Tag).WithField("sharedDigest", digest).WithField("alsoUsedByTags", nonDeletableTagsForDigest).WithField("replacementDigest", replacementTag.Descriptor.Digest.String()).Info("Digest is shared with non-deletable tags - retagging to disposable digest for safe untag")
+
+					if *dry {
+						logger.WithField("tag", tag.Tag).WithField("replacementDigest", replacementTag.Descriptor.Digest.String()).Infof("Not actually retagging/deleting digest (-dry=%v)", *dry)
+						continue
+					}
+
+					if err := tagsService.Tag(ctx, tag.Tag, replacementTag.Descriptor); err != nil {
+						logger.WithField("tag", tag.Tag).WithField("replacementDigest", replacementTag.Descriptor.Digest.String()).WithField("err", err).Error("Could not retag image to disposable digest!")
+						continue
+					}
+
+					if err := manifestService.Delete(ctx, replacementTag.Descriptor.Digest); err != nil {
+						logger.WithField("tag", tag.Tag).WithField("replacementDigest", replacementTag.Descriptor.Digest.String()).WithField("err", err).Error("Could not delete disposable digest after retagging!")
+						continue
+					}
+
+					digestsDeleted[replacementTag.Descriptor.Digest.String()] = true
 				}
 			} else {
 				logger.WithField("tag", tag.Tag).Debug("Image under tag already deleted")

--- a/main.go
+++ b/main.go
@@ -362,17 +362,11 @@ func main() {
 			}
 		}
 
-		deletionOrder := make([]int, 0, len(deletableTags))
-		for tagIndex := range deletableTags {
-			deletionOrder = append(deletionOrder, tagIndex)
-		}
-
 		digestsDeleted := make(map[string]bool)
 
 		// Phase 1: shared digests first. Retag outdated tags to disposable
 		// digests and delete those disposable digests.
-		for _, tagIndex := range deletionOrder {
-			tag := deletableTags[tagIndex]
+		for _, tag := range deletableTags {
 			digest := tag.Descriptor.Digest.String()
 
 			if digestsDeleted[digest] {
@@ -428,8 +422,7 @@ func main() {
 		}
 
 		// Phase 2: non-shared digests. Delete digest directly.
-		for _, tagIndex := range deletionOrder {
-			tag := deletableTags[tagIndex]
+		for _, tag := range deletableTags {
 			digest := tag.Descriptor.Digest.String()
 
 			if digestsDeleted[digest] {

--- a/main.go
+++ b/main.go
@@ -366,13 +366,11 @@ func main() {
 		for tagIndex := range deletableTags {
 			deletionOrder = append(deletionOrder, tagIndex)
 		}
-		sort.Ints(deletionOrder)
 
 		replacementDigestOrder := make([]string, 0, len(replacementDigests))
 		for digest := range replacementDigests {
 			replacementDigestOrder = append(replacementDigestOrder, digest)
 		}
-		sort.Strings(replacementDigestOrder)
 
 		digestsDeleted := make(map[string]bool)
 


### PR DESCRIPTION
## Summary

**Safely deletes images even when their digest is shared with non-deletable tags**, by retagging the outdated tag to a disposable digest before deletion.

## Problem

The current deletion logic skips images entirely when their underlying digest is also referenced by a tag that should be preserved. This means outdated tags sharing a digest with a non-deletable tag are never cleaned up.

## Solution

### Two-phase deletion (`main.go`)

**Phase 1 — Shared digests**: For deletable tags whose digest is also used by non-deletable tags:
1. Find a "disposable" replacement digest (one that belongs to a deletable-only tag)
2. Retag the outdated tag to point at that disposable digest via manifest `Get`+`Put`
3. Delete the disposable digest

**Phase 2 — Non-shared digests**: Delete remaining deletable digests directly (original behavior).

## Additional improvements

- Use explicit map existence checks (`_, exists := m[k]`) instead of zero-value comparisons
- Flatten nested conditionals into early-continue guard clauses
- Consume used replacement digests from the pool to prevent reuse